### PR TITLE
Add CCF badge rendering for publications

### DIFF
--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -32,6 +32,9 @@
       {% else %}
         <a href="{{ base_path }}{{ post.url }}" rel="permalink">{{ title }}</a>
       {% endif %}
+      {% if post.ccf %}
+        <span class="archive__item-ccf">CCF-{{ post.ccf | upcase }}</span>
+      {% endif %}
     </h2>
     
     {% if post.read_time %}

--- a/_publications/2024-02-17-paper-title-number-4.md
+++ b/_publications/2024-02-17-paper-title-number-4.md
@@ -7,6 +7,8 @@ excerpt: 'Decompiling Binary Code with Large Language Models'
 date: 2024-02-17
 venue: 'GitHub Journal of Bugs'
 paperurl: 'https://arxiv.org/pdf/2403.05286'
+# Optional fields for extra metadata
+ccf: A
 # citation: 'Your Name, You. (2024). &quot;Paper Title Number 3.&quot; <i>GitHub Journal of Bugs</i>. 1(3).'
 ---
 

--- a/_sass/_archive.scss
+++ b/_sass/_archive.scss
@@ -42,6 +42,28 @@
 .archive__item-title {
   margin-bottom: 0.25em;
   font-family: $sans-serif-narrow;
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+
+  > a:first-child {
+    flex-grow: 1;
+  }
+
+  .archive__item-ccf {
+    margin-left: auto;
+    padding: 0.15rem 0.45rem;
+    font-size: 0.55em;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    color: mix(#fff, $primary-color, 25%);
+    background-color: mix(#fff, $primary-color, 85%);
+    border: 1px solid mix(#fff, $primary-color, 55%);
+    border-radius: $border-radius;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
 
   a + a {
     opacity: 0.5;


### PR DESCRIPTION
## Summary
- render an optional CCF tier badge next to publication titles in the archive listing
- style the archive title row so the badge aligns to the right without impacting existing links
- document the new metadata flag on an example publication entry

## Testing
- bundle exec jekyll build *(fails: bundler: command not found)*
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d9f15c3a4c8332b72035a9851ba40d